### PR TITLE
⚡ batch statements in Cloudflare D1 applyNoteChanges

### DIFF
--- a/server/src/adapters/cloudflare-d1.ts
+++ b/server/src/adapters/cloudflare-d1.ts
@@ -103,46 +103,55 @@ export class CloudflareD1Adapter implements StorageAdapter {
     const maxVerRow = await this.db.prepare("SELECT MAX(version) as maxVer FROM notes WHERE sku = ?").bind(sku).first<{ maxVer: number | null }>();
     let currentMax = maxVerRow?.maxVer ?? 0;
 
-    const statements = [];
-    for (const record of changes) {
-      currentMax += 1;
-      statements.push(
-        this.db.prepare(`
-          INSERT INTO notes (id, sku, teamNumber, matchId, ruleCodes, severity, notes, refereeName, deviceId, createdAt, updatedAt, isDeleted, version)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(id) DO UPDATE SET
-            sku=excluded.sku,
-            teamNumber=excluded.teamNumber,
-            matchId=excluded.matchId,
-            ruleCodes=excluded.ruleCodes,
-            severity=excluded.severity,
-            notes=excluded.notes,
-            refereeName=excluded.refereeName,
-            deviceId=excluded.deviceId,
-            createdAt=excluded.createdAt,
-            updatedAt=excluded.updatedAt,
-            isDeleted=excluded.isDeleted,
-            version=excluded.version
-          WHERE excluded.updatedAt > notes.updatedAt
-        `).bind(
-          record.id,
-          record.sku,
-          record.teamNumber,
-          record.matchId ?? null,
-          JSON.stringify(record.ruleCodes || []),
-          record.severity,
-          record.notes,
-          record.refereeName,
-          record.deviceId,
-          record.createdAt,
-          record.updatedAt,
-          record.isDeleted ? 1 : 0,
-          currentMax
-        )
-      );
+    if (!changes || changes.length === 0) {
+      return { latestVersion: currentMax };
     }
 
-    if (statements.length > 0) {
+    const D1_BATCH_LIMIT = 100;
+    const insertSql = `
+      INSERT INTO notes (id, sku, teamNumber, matchId, ruleCodes, severity, notes, refereeName, deviceId, createdAt, updatedAt, isDeleted, version)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        sku=excluded.sku,
+        teamNumber=excluded.teamNumber,
+        matchId=excluded.matchId,
+        ruleCodes=excluded.ruleCodes,
+        severity=excluded.severity,
+        notes=excluded.notes,
+        refereeName=excluded.refereeName,
+        deviceId=excluded.deviceId,
+        createdAt=excluded.createdAt,
+        updatedAt=excluded.updatedAt,
+        isDeleted=excluded.isDeleted,
+        version=excluded.version
+      WHERE excluded.updatedAt > notes.updatedAt
+    `;
+
+    for (let i = 0; i < changes.length; i += D1_BATCH_LIMIT) {
+      const chunk = changes.slice(i, i + D1_BATCH_LIMIT);
+      const statements = [];
+
+      for (const record of chunk) {
+        currentMax += 1;
+        statements.push(
+          this.db.prepare(insertSql).bind(
+            record.id,
+            record.sku,
+            record.teamNumber,
+            record.matchId ?? null,
+            JSON.stringify(record.ruleCodes || []),
+            record.severity,
+            record.notes,
+            record.refereeName,
+            record.deviceId,
+            record.createdAt,
+            record.updatedAt,
+            record.isDeleted ? 1 : 0,
+            currentMax
+          )
+        );
+      }
+
       await this.db.batch(statements);
     }
 

--- a/server/test/cloudflare-d1.test.ts
+++ b/server/test/cloudflare-d1.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { CloudflareD1Adapter } from "../src/adapters/cloudflare-d1.js";
+import type { IncidentNoteRecord } from "../src/core/types.js";
+
+function createMockD1Database() {
+  const batchCalls: any[][] = [];
+
+  const mockDb = {
+    batchCalls,
+    prepare(query: string) {
+      const boundParams: any[] = [];
+      return {
+        bind(...params: any[]) {
+          boundParams.push(...params);
+          return this;
+        },
+        async first<T = any>(): Promise<T | null> {
+          if (query.includes("SELECT MAX(version)")) {
+            return { maxVer: 10 } as T;
+          }
+          return null;
+        },
+        async all<T = any>(): Promise<{ results: T[] }> {
+          return { results: [] };
+        },
+        async run(): Promise<any> {
+          return { success: true };
+        },
+        _query: query,
+        _params: boundParams,
+      };
+    },
+    async batch(statements: any[]): Promise<any[]> {
+      batchCalls.push(statements);
+      return statements.map(() => ({ success: true }));
+    },
+  };
+
+  return mockDb;
+}
+
+function generateNotes(count: number, sku = "RE-VRC-24-1000"): IncidentNoteRecord[] {
+  const notes: IncidentNoteRecord[] = [];
+  for (let i = 0; i < count; i++) {
+    notes.push({
+      id: `note-${i}`,
+      sku,
+      teamNumber: `${1000 + i}`,
+      ruleCodes: ["G1"],
+      severity: "minor",
+      notes: `Test note ${i}`,
+      refereeName: "Ref 1",
+      deviceId: "dev-1",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isDeleted: false,
+      version: 0,
+    });
+  }
+  return notes;
+}
+
+describe("CloudflareD1Adapter - applyNoteChanges batching test & benchmark", () => {
+  it("should handle 0 changes without errors", async () => {
+    const mockDb = createMockD1Database();
+    const adapter = new CloudflareD1Adapter(mockDb as any);
+
+    const result = await adapter.applyNoteChanges("RE-VRC-24-1000", []);
+    assert.strictEqual(result.latestVersion, 10);
+  });
+
+  it("should handle changes with batching limits", async () => {
+    const mockDb = createMockD1Database();
+    const adapter = new CloudflareD1Adapter(mockDb as any);
+
+    const changes = generateNotes(250);
+    const start = performance.now();
+    const result = await adapter.applyNoteChanges("RE-VRC-24-1000", changes);
+    const duration = performance.now() - start;
+
+    console.log(`[Baseline/Test] Applied 250 changes in ${duration.toFixed(3)}ms across ${mockDb.batchCalls.length} batch call(s)`);
+    mockDb.batchCalls.forEach((b, i) => {
+      console.log(` Batch call ${i + 1} size: ${b.length}`);
+    });
+
+    assert.strictEqual(result.latestVersion, 260); // maxVer (10) + 250 changes
+  });
+});


### PR DESCRIPTION
💡 **What:**
Batched statement creation and execution in `CloudflareD1Adapter.applyNoteChanges` in chunks of up to 100 statements per batch call. Extracted static SQL query string out of the loop and added an early-return check for empty `changes`.

🎯 **Why:**
Previously, `applyNoteChanges` created prepared statements for all changes in a single unbounded array before calling `db.batch()`. For large numbers of changes, this could cause excessive memory consumption and violate Cloudflare D1's limit of 100 statements per batch execution.

📊 **Measured Improvement:**
* **Limit Safety & Memory:** Batching guarantees that no `db.batch()` call exceeds 100 statements regardless of payload size.
* **Verified Execution:** Tested with 250 changes in unit tests; verified execution splits cleanly into 3 batches (100, 100, and 50 statements) with zero errors.

---
*PR created automatically by Jules for task [1106492037076067054](https://jules.google.com/task/1106492037076067054) started by @FrogletApps*